### PR TITLE
also consider builddependencies when config passed to template_constant_dict is not an EasyConfig instance yet + add comments to clarify what's going on

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -216,12 +216,29 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
         # copy to avoid changing original list below
         deps = copy.copy(config.get('dependencies', []))
 
-        if hasattr(config, 'iterating'):
+        # also consider build dependencies for *ver and *shortver templates;
+        # we need to be a bit careful here, because for iterative installations
+        # (when multi_deps is used for example) the builddependencies value may be a list of lists
+
+        # first, determine if we have an EasyConfig instance
+        # (indirectly by checking for 'iterating' and 'iterate_options' attributes,
+        #  because we can't import the EasyConfig class here without introducing
+        #  a cyclic import...)
+        is_easyconfig = hasattr(config, 'iterating') and hasattr(config, 'iterate_options')
+
+        if is_easyconfig:
+            # if we're iterating of different lists of build dependencies,
+            # only consider build dependencies when we're actually in iterative mode!
             if 'builddependencies' in config.iterate_options:
                 if config.iterating:
                     deps += config.get('builddependencies', [])
             else:
                 deps += config.get('builddependencies', [])
+
+        # if we're not dealing with an EasyConfig instance,
+        # we can just add list of builddependencies directly (no list of lists in that case)
+        else:
+            deps += config.get('builddependencies', [])
 
         for dep in deps:
             if isinstance(dep, dict):


### PR DESCRIPTION
@ekouts Update for https://github.com/easybuilders/easybuild-framework/pull/3346